### PR TITLE
Fixed .helpmessage visible in theme_unil2

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -186,6 +186,10 @@
     width: 0%;
 }
 
+.assignfeedback_editpdfplus_widget .helpmessage {
+    display: none;
+}
+
 .assignfeedback_editpdfplus_widget .btn-toolbar {
     min-height:50px;
 }


### PR DESCRIPTION
`.helpmessage` div is visible when scrolling down in grading interface